### PR TITLE
Ignore resource labels and instrumentation library labels.

### DIFF
--- a/trace_test.go
+++ b/trace_test.go
@@ -125,7 +125,7 @@ func TestBasicTrace(t *testing.T) {
 		if strings.HasPrefix(key, "g.co/r/") {
 			continue
 		}
-		if strings.HasPrefix(key, "otel.instrumentation_library") {
+		if strings.HasPrefix(key, "otel.scope") {
 			continue
 		}
 		numLabels += 1

--- a/trace_test.go
+++ b/trace_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math/rand"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -118,8 +119,20 @@ func TestBasicTrace(t *testing.T) {
 		span.Name,
 	)
 
-	if numLabels := len(span.Labels); numLabels != 2 {
-		t.Fatalf("Expected exactly 2 labels, got %v", numLabels)
+	// Ignore-able labels (resource, instrumentation library)
+	numLabels := 0
+	for key := range span.Labels {
+		if strings.HasPrefix(key, "g.co/r/") {
+			continue
+		}
+		if strings.HasPrefix(key, "otel.instrumentation_library") {
+			continue
+		}
+		numLabels += 1
+	}
+
+	if numLabels != 2 {
+		t.Fatalf("Expected exactly 2 non-resource labels, got %v", numLabels)
 	}
 
 	labelCases := []struct {


### PR DESCRIPTION
- Ignore resource labels on spans in e2e tests (`g.co/r`)
- For now, abide by Trace Exporter Specification and ignore `otel.instrumentation_library.*` span labels.