### PR TITLE
Set include_build_logs on build triggers

### DIFF
--- a/tf/common/main-common.tf
+++ b/tf/common/main-common.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "3.74.0"
+      version = "4.26.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/tf/gke/gke.tf
+++ b/tf/gke/gke.tf
@@ -68,11 +68,11 @@ resource "kubernetes_pod" "testserver" {
         }
       }
       env {
-        name = "CONTAINER_NAME"
+        name  = "CONTAINER_NAME"
         value = "fake-container-name"
       }
       env {
-        name = "OTEL_RESOURCE_ATTRIBUTES"
+        name  = "OTEL_RESOURCE_ATTRIBUTES"
         value = "k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE_NAME),k8s.container.name=$(CONTAINER_NAME)"
       }
     }

--- a/tf/modules/repo-ci-triggers/main.tf
+++ b/tf/modules/repo-ci-triggers/main.tf
@@ -31,6 +31,7 @@ resource "google_cloudbuild_trigger" "build_image" {
     local.repo_short_name,
     "build"
   ]
+  include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
 }
 
 // Run tests
@@ -52,6 +53,7 @@ resource "google_cloudbuild_trigger" "ci" {
     local.repo_short_name,
     each.key,
   ]
+  include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
 }
 
 variable "repository" {


### PR DESCRIPTION
See docs at https://cloud.google.com/build/docs/api/reference/rest/v1/projects.triggers#BuildTrigger.FIELDS.include_build_logs. This will post a link to the build logs on Github CI actions.