### PR TITLE
Enables java tests to run in cloud-run

### DIFF
--- a/tf/persistent/repo-ci-triggers.tf
+++ b/tf/persistent/repo-ci-triggers.tf
@@ -21,7 +21,7 @@ module "python" {
 module "java" {
   source     = "../modules/repo-ci-triggers"
   repository = "opentelemetry-operations-java"
-  run_on     = ["local", "gce", "gke"]
+  run_on     = ["local", "gce", "gke", "cloud-run"]
 }
 
 module "js" {


### PR DESCRIPTION
Adds cloud-run to the list of GCP platforms on which e2e java tests run.



 