### PR TITLE
Enable Google App Engine environment for e2e tests

### DIFF
--- a/e2e_testing.go
+++ b/e2e_testing.go
@@ -56,6 +56,12 @@ type GkeCmd struct {
 	CmdWithImage
 }
 
+type GaeCmd struct {
+	CmdWithImage
+
+	Runtime string `arg:"required" help:"The language runtime for the instrumented test server, used in naming the service"`
+}
+
 type CloudRunCmd struct {
 	CmdWithImage
 }
@@ -78,6 +84,7 @@ type Args struct {
 	Local              *LocalCmd              `arg:"subcommand:local" help:"Deploy the test server locally with docker and execute tests"`
 	Gke                *GkeCmd                `arg:"subcommand:gke" help:"Deploy the test server on GKE and execute tests"`
 	Gce                *GceCmd                `arg:"subcommand:gce" help:"Deploy the test server on GCE and execute tests"`
+	Gae                *GaeCmd                `arg:"subcommand:gae" help:"Deploy the test server on GAE and execute tests"`
 	CloudRun           *CloudRunCmd           `arg:"subcommand:cloud-run" help:"Deploy the test server on Cloud Run and execute tests"`
 	CloudFunctionsGen2 *CloudFunctionsGen2Cmd `arg:"subcommand:cloud-functions-gen2" help:"Deploy the test server on Cloud Function (2nd Gen) and execute tests"`
 

--- a/main_test.go
+++ b/main_test.go
@@ -78,6 +78,8 @@ func TestMain(m *testing.M) {
 		setupFunc = SetupCloudRun
 	case args.CloudFunctionsGen2 != nil:
 		setupFunc = SetupCloudFunctionsGen2
+	case args.Gae != nil:
+		setupFunc = SetupGae
 	}
 	client, cleanup, err := setupFunc(ctx, &args, logger)
 

--- a/setupgae.go
+++ b/setupgae.go
@@ -1,0 +1,49 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e_testing
+
+import (
+	"context"
+	"log"
+
+	"github.com/GoogleCloudPlatform/opentelemetry-operations-e2e-testing/setuptf"
+	"github.com/GoogleCloudPlatform/opentelemetry-operations-e2e-testing/testclient"
+)
+
+const gaeTfDir string = "tf/gae"
+
+func SetupGae(
+	ctx context.Context,
+	args *Args,
+	logger *log.Logger,
+) (*testclient.Client, Cleanup, error) {
+	pubsubInfo, cleanupTf, err := setuptf.SetupTf(
+		ctx,
+		args.ProjectID,
+		args.TestRunID,
+		gaeTfDir,
+		map[string]string{
+			"image":   args.Gae.Image,
+			"runtime": args.Gae.Runtime,
+		},
+		logger,
+	)
+	if err != nil {
+		return nil, cleanupTf, err
+	}
+
+	client, err := testclient.New(ctx, args.ProjectID, pubsubInfo)
+	return client, cleanupTf, err
+}

--- a/tf/gae/gae.tf
+++ b/tf/gae/gae.tf
@@ -1,0 +1,87 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Not enabling the permissions on the default service account here 
+# Since the permissions bindings specified here will be removed when the 
+# terraform cleanup happens, that causes failures in app engine flex 
+# environment. These permissions should be granted through the latch-key configurations.
+
+resource "google_app_engine_flexible_app_version" "test_service" {
+  version_id = "v1"
+  project    = var.project_id
+  service    = "test-service-${var.runtime}-${terraform.workspace}"
+  runtime    = "custom"
+
+  deployment {
+    container {
+      image = var.image
+    }
+  }
+
+  liveness_check {
+    path = "/alive"
+  }
+
+  readiness_check {
+    path = "/ready"
+  }
+
+  automatic_scaling {
+    cool_down_period = "120s"
+    cpu_utilization {
+      target_utilization = 0.9
+    }
+    max_total_instances = 1 
+    min_total_instances = 1 
+  }
+
+  env_variables = {
+    "PUSH_PORT" = "8080",
+    "REQUEST_SUBSCRIPTION_NAME" = module.pubsub.info.request_topic.subscription_name,
+    "RESPONSE_TOPIC_NAME" = module.pubsub.info.response_topic.topic_name,
+    "PROJECT_ID" = var.project_id,
+    "SUBSCRIPTION_MODE" = "push"
+  }
+
+  noop_on_destroy = false
+  delete_service_on_destroy = true
+  service_account = "${var.project_id}@appspot.gserviceaccount.com"
+}
+
+module "pubsub" {
+  source = "../modules/pubsub"
+
+  project_id = var.project_id
+}
+
+module "pubsub-push-subscription" {
+  source = "../modules/pubsub-push-subscription"
+
+  project_id    = var.project_id
+  topic         = module.pubsub.info.request_topic.topic_name
+  push_endpoint = "https://${google_app_engine_flexible_app_version.test_service.service}-dot-${var.project_id}.uc.r.appspot.com/"
+}
+
+variable "image" {
+  type = string
+}
+
+variable "runtime" {
+    type = string
+}
+
+output "pubsub_info" {
+  value       = module.pubsub.info
+  description = "Info about the request/response pubsub topics and subscription to use in the test"
+}

--- a/tf/gae/main-common.tf
+++ b/tf/gae/main-common.tf
@@ -1,0 +1,1 @@
+../common/main-common.tf

--- a/tf/modules/repo-ci-triggers/main.tf
+++ b/tf/modules/repo-ci-triggers/main.tf
@@ -65,8 +65,8 @@ variable "run_on" {
   type        = set(string)
   description = "The GCP resources to run the tests on."
   validation {
-    condition     = alltrue([for r in var.run_on : contains(["local", "gke", "gce", "cloud-run", "cloud-functions-gen2"], r)])
-    error_message = "Variable run_on must be one of: 'local' | 'gke' | 'gce' | 'cloud-run' | 'cloud-functions-gen2'."
+    condition     = alltrue([for r in var.run_on : contains(["local", "gke", "gce", "gae", "cloud-run", "cloud-functions-gen2"], r)])
+    error_message = "Variable run_on must be one of: 'local' | 'gke' | 'gce' | 'gae' | 'cloud-run' | 'cloud-functions-gen2'."
   }
 }
 

--- a/tf/persistent/repo-ci-triggers.tf
+++ b/tf/persistent/repo-ci-triggers.tf
@@ -21,7 +21,7 @@ module "python" {
 module "java" {
   source     = "../modules/repo-ci-triggers"
   repository = "opentelemetry-operations-java"
-  run_on     = ["local", "gce", "gke", "cloud-run", "cloud-functions-gen2"]
+  run_on     = ["local", "gce", "gke", "gae", "cloud-run", "cloud-functions-gen2"]
 }
 
 module "js" {

--- a/trace_test.go
+++ b/trace_test.go
@@ -249,6 +249,9 @@ func TestResourceDetectionTrace(t *testing.T) {
 			labelExpectation{expectKey: "g.co/r/cloud_function/region", expectRe: `.*-.*`},
 			labelExpectation{expectKey: "g.co/r/cloud_function/function_name", expectRe: `.*`},
 		)
+	default:
+		t.Logf("Unexpected GCP environment provided. Make sure to add handling for all expected GCP environments.")
+		t.FailNow()
 	}
 	for _, tc := range labelCases {
 		t.Run(fmt.Sprintf("Span has label %v", tc.expectKey), func(t *testing.T) {

--- a/trace_test.go
+++ b/trace_test.go
@@ -249,6 +249,13 @@ func TestResourceDetectionTrace(t *testing.T) {
 			labelExpectation{expectKey: "g.co/r/cloud_function/region", expectRe: `.*-.*`},
 			labelExpectation{expectKey: "g.co/r/cloud_function/function_name", expectRe: `.*`},
 		)
+	case args.Gae != nil:
+		labelCases = append(labelCases,
+			labelExpectation{expectKey: "g.co/r/gae_instance/module_id", expectRe: `.*`},
+			labelExpectation{expectKey: "g.co/r/gae_instance/version_id", expectRe: `.*`},
+			labelExpectation{expectKey: "g.co/r/gae_instance/instance_id", expectRe: `.*`},
+			labelExpectation{expectKey: "g.co/r/gae_instance/location", expectRe: `.*-.*`},
+		)
 	default:
 		t.Logf("Unexpected GCP environment provided. Make sure to add handling for all expected GCP environments.")
 		t.FailNow()


### PR DESCRIPTION
This PR enables tests to run in GAE by automating the creation of GAE flex service which is able to run a containerized version of the language specific instrumented test server. 

### Testing
 - Manually tested against an image of instrumented test server for Java repo *(modified to support GAE)*. The tests ran. 
 - All required permissions have been granted through latchkey configs. 
 - The resource detection test passed when run against an instrumented Java server with resource detection enabled for GAE. 
 - The repository CI trigger for Java has been enabled as part of this PR. (_Ran the apply-persistent script - the CI trigger has already been created_).