### PR TITLE
Run gae and cloud run tests on go repo

### DIFF
--- a/tf/persistent/repo-ci-triggers.tf
+++ b/tf/persistent/repo-ci-triggers.tf
@@ -33,5 +33,5 @@ module "js" {
 module "go" {
   source     = "../modules/repo-ci-triggers"
   repository = "opentelemetry-operations-go"
-  run_on     = ["local", "gce", "gke"]
+  run_on     = ["local", "gce", "gke", "gae", "cloud-run"]
 }


### PR DESCRIPTION
Required for https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/551