### PR TITLE
Fix image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.16 AS gobuild
+FROM golang:1.20 AS gobuild
 WORKDIR /src
 
 # cache deps before copying source so that we don't re-download as much

--- a/setuplocal.go
+++ b/setuplocal.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"time"
 
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-e2e-testing/setuptf"
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-e2e-testing/testclient"
@@ -90,8 +89,8 @@ func SetupLocal(
 
 	cleanup := func() {
 		logger.Printf("Stopping and removing container ID %v\n", containerID)
-		timeout := (time.Second * 15)
-		err = cli.ContainerStop(ctx, containerID, &timeout)
+		timeout := 15
+		err = cli.ContainerStop(ctx, containerID, container.StopOptions{Timeout: &timeout})
 		defer removeContainer()
 		if err != nil {
 			logger.Panic(err)
@@ -116,7 +115,7 @@ func createContainer(
 	args *Args,
 	pubsubInfo *setuptf.PubsubInfo,
 	logger *log.Logger,
-) (container.ContainerCreateCreatedBody, error) {
+) (container.CreateResponse, error) {
 	env := []string{
 		"PORT=" + args.Local.Port,
 		"PROJECT_ID=" + args.ProjectID,


### PR DESCRIPTION
Builds now:

```
$ docker build .
[+] Building 26.4s (22/22) FINISHED                                                                                                                                                                                                 docker:default
 => [internal] load .dockerignore                                                                                                                                                                                                             0.3s
 => => transferring context: 126B                                                                                                                                                                                                             0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                                                          0.1s
 => => transferring dockerfile: 1.46kB                                                                                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/library/alpine:3.14                                                                                                                                                                                0.0s
 => [internal] load metadata for docker.io/library/golang:1.20                                                                                                                                                                                0.3s
 => [internal] load metadata for docker.io/hashicorp/terraform:light                                                                                                                                                                          0.0s
 => [gobuild 1/6] FROM docker.io/library/golang:1.20@sha256:ddcc9c29fc589c10a26dd59198873510a526e7d1a3d81f6903690255f1118e4e                                                                                                                  0.0s
 => [internal] load build context                                                                                                                                                                                                             0.0s
 => => transferring context: 7.39kB                                                                                                                                                                                                           0.0s
 => [stage-2 1/5] FROM docker.io/library/alpine:3.14                                                                                                                                                                                          0.0s
 => [tfbuild 1/4] FROM docker.io/hashicorp/terraform:light                                                                                                                                                                                    0.0s
 => CACHED [gobuild 2/6] WORKDIR /src                                                                                                                                                                                                         0.0s
 => CACHED [gobuild 3/6] COPY go.mod go.sum ./                                                                                                                                                                                                0.0s
 => CACHED [gobuild 4/6] RUN go mod download                                                                                                                                                                                                  0.0s
 => [gobuild 5/6] COPY . .                                                                                                                                                                                                                    0.5s
 => [gobuild 6/6] RUN CGO_ENABLED=0 go test -c                                                                                                                                                                                               17.5s
 => CACHED [stage-2 2/5] RUN apk --update add ca-certificates git                                                                                                                                                                             0.0s
 => CACHED [tfbuild 2/4] COPY tf /src/tf                                                                                                                                                                                                      0.0s
 => CACHED [tfbuild 3/4] WORKDIR /src/tf                                                                                                                                                                                                      0.0s
 => CACHED [tfbuild 4/4] RUN for dir in */; do (cd $dir && terraform init -backend=false); done                                                                                                                                               0.0s
 => [stage-2 3/5] COPY --from=gobuild /src/opentelemetry-operations-e2e-testing.test /opentelemetry-operations-e2e-testing.test                                                                                                               0.4s
 => [stage-2 4/5] COPY --from=tfbuild /src/tf /tf                                                                                                                                                                                             4.2s
 => [stage-2 5/5] COPY --from=tfbuild /bin/terraform /bin/terraform                                                                                                                                                                           2.1s
 => exporting to image                                                                                                                                                                                                                        0.7s
 => => exporting layers                                                                                                                                                                                                                       0.7s
 => => writing image sha256:17753b7e861bbf2842d6892bf3337411c283382b748992b90c802e5176d4025f
```