### PR TITLE
Add GAE standard support to test runner

### DIFF
--- a/e2e_testing.go
+++ b/e2e_testing.go
@@ -62,6 +62,11 @@ type GaeCmd struct {
 	Runtime string `arg:"required" help:"The language runtime for the instrumented test server, used in naming the service"`
 }
 
+type GaeStandardCmd struct {
+	Runtime   string `arg:"required" help:"The language runtime for the instrumented test server, used in naming the service"`
+	AppSource string `arg:"required" help:"The full path of the zip file that contains the source code to run in GAE"`
+}
+
 type CloudRunCmd struct {
 	CmdWithImage
 }
@@ -85,6 +90,7 @@ type Args struct {
 	Gke                *GkeCmd                `arg:"subcommand:gke" help:"Deploy the test server on GKE and execute tests"`
 	Gce                *GceCmd                `arg:"subcommand:gce" help:"Deploy the test server on GCE and execute tests"`
 	Gae                *GaeCmd                `arg:"subcommand:gae" help:"Deploy the test server on GAE and execute tests"`
+	GaeStandard        *GaeStandardCmd        `arg:"subcommand:gae-standard" help:"Deploy the test server on GAE standard and execute tests"`
 	CloudRun           *CloudRunCmd           `arg:"subcommand:cloud-run" help:"Deploy the test server on Cloud Run and execute tests"`
 	CloudFunctionsGen2 *CloudFunctionsGen2Cmd `arg:"subcommand:cloud-functions-gen2" help:"Deploy the test server on Cloud Function (2nd Gen) and execute tests"`
 

--- a/main_test.go
+++ b/main_test.go
@@ -80,6 +80,8 @@ func TestMain(m *testing.M) {
 		setupFunc = SetupCloudFunctionsGen2
 	case args.Gae != nil:
 		setupFunc = SetupGae
+	case args.GaeStandard != nil:
+		setupFunc = SetupGaeStandard
 	}
 	client, cleanup, err := setupFunc(ctx, &args, logger)
 

--- a/setupgaestandard.go
+++ b/setupgaestandard.go
@@ -1,0 +1,49 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e_testing
+
+import (
+	"context"
+	"log"
+
+	"github.com/GoogleCloudPlatform/opentelemetry-operations-e2e-testing/setuptf"
+	"github.com/GoogleCloudPlatform/opentelemetry-operations-e2e-testing/testclient"
+)
+
+const gaeStandardTfDir string = "tf/gae-standard"
+
+func SetupGaeStandard(
+	ctx context.Context,
+	args *Args,
+	logger *log.Logger,
+) (*testclient.Client, Cleanup, error) {
+	pubsubInfo, cleanupTf, err := setuptf.SetupTf(
+		ctx,
+		args.ProjectID,
+		args.TestRunID,
+		gaeStandardTfDir,
+		map[string]string{
+			"runtime":   args.GaeStandard.Runtime,
+			"appsource": args.GaeStandard.AppSource,
+		},
+		logger,
+	)
+	if err != nil {
+		return nil, cleanupTf, err
+	}
+
+	client, err := testclient.New(ctx, args.ProjectID, pubsubInfo)
+	return client, cleanupTf, err
+}

--- a/tf/gae-standard/gae-standard.tf
+++ b/tf/gae-standard/gae-standard.tf
@@ -1,0 +1,90 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Not enabling the permissions on the default service account here Since the permissions
+# bindings specified here will be removed when the terraform cleanup happens, that causes
+# failures in app engine environment. These permissions should be granted through the latch-key
+# configurations.
+
+resource "google_app_engine_standard_app_version" "test_service" {
+
+  version_id = "v1"
+  project    = var.project_id
+  service    = "test-standard-service-${var.runtime}-${terraform.workspace}"
+  runtime    = var.runtime
+
+  deployment {
+    zip {
+      // The object's media_link does not work, GAE requires this format
+      // https://cloud.google.com/appengine/docs/admin-api/reference/rpc/google.appengine.v1#zipinfo
+      source_url = "https://storage.googleapis.com/${google_storage_bucket.bucket.name}/${google_storage_bucket_object.object.name}"
+    }
+  }
+
+  // Required, but leave empty to fall back to the runtime default
+  entrypoint {
+    shell = ""
+  }
+
+  env_variables = {
+    "PUSH_PORT"                 = "8080",
+    "REQUEST_SUBSCRIPTION_NAME" = module.pubsub.info.request_topic.subscription_name,
+    "RESPONSE_TOPIC_NAME"       = module.pubsub.info.response_topic.topic_name,
+    "PROJECT_ID"                = var.project_id,
+    "SUBSCRIPTION_MODE"         = "push"
+  }
+
+  noop_on_destroy           = false
+  delete_service_on_destroy = true
+}
+
+resource "google_storage_bucket" "bucket" {
+  name                        = "${terraform.workspace}-appsource" # Every bucket name must be globally unique
+  location                    = "US"
+  uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket_object" "object" {
+  name   = "appsource.zip"
+  bucket = google_storage_bucket.bucket.name
+  # Add path to the zipped function source code, source file zip should be in the bucket
+  source = var.appsource
+}
+
+module "pubsub" {
+  source = "../modules/pubsub"
+
+  project_id = var.project_id
+}
+
+module "pubsub-push-subscription" {
+  source = "../modules/pubsub-push-subscription"
+
+  project_id    = var.project_id
+  topic         = module.pubsub.info.request_topic.topic_name
+  push_endpoint = "https://${google_app_engine_standard_app_version.test_service.service}-dot-${var.project_id}.uc.r.appspot.com/"
+}
+
+variable "appsource" {
+  type = string
+}
+
+variable "runtime" {
+  type = string
+}
+
+output "pubsub_info" {
+  value       = module.pubsub.info
+  description = "Info about the request/response pubsub topics and subscription to use in the test"
+}

--- a/tf/gae-standard/main-common.tf
+++ b/tf/gae-standard/main-common.tf
@@ -1,0 +1,1 @@
+../common/main-common.tf

--- a/trace_test.go
+++ b/trace_test.go
@@ -277,6 +277,18 @@ func TestResourceDetectionTrace(t *testing.T) {
 			labelExpectation{expectKey: "faas.instance", expectRe: `.*`},
 			labelExpectation{expectKey: "faas.version", expectRe: `.*`},
 		)
+	case args.GaeStandard != nil:
+		labelCases = append(labelCases,
+			labelExpectation{expectKey: "cloud.provider", expectRe: `gcp`},
+			labelExpectation{expectKey: "cloud.platform", expectRe: `gcp_app_engine`},
+			// GAE standard zones do not use the regular consistent GCP public zone names, but
+			// this regex verifies that the "/" characters are stripped away
+			labelExpectation{expectKey: "cloud.availability_zone", expectRe: `[\w\-]+`},
+			labelExpectation{expectKey: "cloud.region", expectRe: `.*-.*`},
+			labelExpectation{expectKey: "faas.name", expectRe: `.*`},
+			labelExpectation{expectKey: "faas.instance", expectRe: `.*`},
+			labelExpectation{expectKey: "faas.version", expectRe: `.*`},
+		)
 	default:
 		t.Logf("Unexpected GCP environment provided. Make sure to add handling for all expected GCP environments.")
 		t.FailNow()


### PR DESCRIPTION
Mostly just copy-pasted from the GAE flex code. I tweaked the regex for the zones a bit.

Tested on JS repo https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/pull/717