### PR TITLE
GAE standard: allow passing entrypoint and shorten service names

### DIFF
--- a/e2e_testing.go
+++ b/e2e_testing.go
@@ -63,8 +63,9 @@ type GaeCmd struct {
 }
 
 type GaeStandardCmd struct {
-	Runtime   string `arg:"required" help:"The language runtime for the instrumented test server, used in naming the service"`
-	AppSource string `arg:"required" help:"The full path of the zip file that contains the source code to run in GAE"`
+	Runtime    string `arg:"required" help:"The language runtime for the instrumented test server, used in naming the service"`
+	AppSource  string `arg:"required" help:"The full path of the zip file that contains the source code to run in GAE"`
+	Entrypoint string `help:"Optional entrypoint to control how GAE starts the application. See https://cloud.google.com/appengine/docs/standard/reference/app-yaml#entrypoint"`
 }
 
 type CloudRunCmd struct {

--- a/setupgaestandard.go
+++ b/setupgaestandard.go
@@ -35,8 +35,9 @@ func SetupGaeStandard(
 		args.TestRunID,
 		gaeStandardTfDir,
 		map[string]string{
-			"runtime":   args.GaeStandard.Runtime,
-			"appsource": args.GaeStandard.AppSource,
+			"runtime":    args.GaeStandard.Runtime,
+			"appsource":  args.GaeStandard.AppSource,
+			"entrypoint": args.GaeStandard.Entrypoint,
 		},
 		logger,
 	)

--- a/tf/gae-standard/gae-standard.tf
+++ b/tf/gae-standard/gae-standard.tf
@@ -21,7 +21,7 @@ resource "google_app_engine_standard_app_version" "test_service" {
 
   version_id = "v1"
   project    = var.project_id
-  service    = "test-standard-service-${var.runtime}-${terraform.workspace}"
+  service    = "standard-${var.runtime}-${terraform.workspace}"
   runtime    = var.runtime
 
   deployment {
@@ -32,9 +32,9 @@ resource "google_app_engine_standard_app_version" "test_service" {
     }
   }
 
-  // Required, but leave empty to fall back to the runtime default
+  // Required, but if variable is unset (empty string), fall back to the runtime default
   entrypoint {
-    shell = ""
+    shell = var.entrypoint
   }
 
   env_variables = {
@@ -82,6 +82,11 @@ variable "appsource" {
 
 variable "runtime" {
   type = string
+}
+
+variable "entrypoint" {
+  type = string
+  default = ""
 }
 
 output "pubsub_info" {

--- a/tf/gae/gae.tf
+++ b/tf/gae/gae.tf
@@ -20,7 +20,7 @@
 resource "google_app_engine_flexible_app_version" "test_service" {
   version_id = "v1"
   project    = var.project_id
-  service    = "test-service-${var.runtime}-${terraform.workspace}"
+  service    = "flex-${var.runtime}-${terraform.workspace}"
   runtime    = "custom"
 
   deployment {


### PR DESCRIPTION
- For some reason, app.yaml can't be used to override `entrypoint`. I think this is because of the way terraform calls the GAE admin API. Instead, allow passing it so individual languages can override if needed.
- The service name was too long. Service name becomes the DNS name and IDNA specifies they should have no "label" (part between dots) longer than 64 characters. This was causing [issues with Flask](https://github.com/pallets/flask/issues/5392).
