### PR TITLE
Set limits on GAE resources

### DIFF
--- a/tf/gae-standard/gae-standard.tf
+++ b/tf/gae-standard/gae-standard.tf
@@ -37,6 +37,14 @@ resource "google_app_engine_standard_app_version" "test_service" {
     shell = var.entrypoint
   }
 
+  // Limit resources and QPS
+  automatic_scaling {
+    max_concurrent_requests = 5
+    standard_scheduler_settings {
+      max_instances = 1
+    }
+  }
+
   env_variables = {
     "PUSH_PORT"                 = "8080",
     "REQUEST_SUBSCRIPTION_NAME" = module.pubsub.info.request_topic.subscription_name,

--- a/tf/gae/gae.tf
+++ b/tf/gae/gae.tf
@@ -37,13 +37,13 @@ resource "google_app_engine_flexible_app_version" "test_service" {
     path = "/ready"
   }
 
+  // Limit resources and QPS
   automatic_scaling {
-    cool_down_period = "120s"
+    max_concurrent_requests = 5
     cpu_utilization {
       target_utilization = 0.9
     }
     max_total_instances = 1
-    min_total_instances = 1
   }
 
   env_variables = {

--- a/tf/gae/gae.tf
+++ b/tf/gae/gae.tf
@@ -44,6 +44,7 @@ resource "google_app_engine_flexible_app_version" "test_service" {
       target_utilization = 0.9
     }
     max_total_instances = 1
+    min_total_instances = 0
   }
 
   env_variables = {


### PR DESCRIPTION
Limits added should prevent
- many instances being scaled up
- many concurrent requests