### PR TITLE
Add quickstarttest library for testing instrumentation quickstarts

### DIFF
--- a/quickstarttest/README.md
+++ b/quickstarttest/README.md
@@ -1,0 +1,23 @@
+This go module is used to test the docker compose based OpenTelemetry instrumentation quickstarts:
+
+- https://cloud.google.com/stackdriver/docs/instrumentation/setup/go
+- https://cloud.google.com/stackdriver/docs/instrumentation/setup/java
+- https://cloud.google.com/stackdriver/docs/instrumentation/setup/nodejs
+- https://cloud.google.com/stackdriver/docs/instrumentation/setup/python
+
+
+The repos hosting the quickstart code use this lib by writing a test that calls
+`InstrumentationQuickstartTest()`. The tests run in a Cloud Build trigger so they can access
+the Cloud Observability APIs.
+
+`InstrumentationQuickstartTest()` runs the instrumentation quickstart docker compose setup in
+the cwd and verifies that metrics, logs, and traces are successfully sent from the collector to
+GCP. It checks the collector's self observability prometheus metrics to verify that the
+exporters were successful.
+
+The `COMPOSE_OVERRIDE_FILE` environment variable can be set to a comma-separated list of paths
+to additional compose files to pass to docker compose (see
+https://docs.docker.com/compose/multiple-compose-files/merge/). This is used in the Cloud Build
+triggers to connect the docker containers to the [`cloudbuild` docker
+network](https://cloud.google.com/build/docs/build-config-file-schema#network) for ADC. It can
+also be used to run the test with `GOOGLE_APPLICATION_CREDENTIALS` for example.

--- a/quickstarttest/testcases.go
+++ b/quickstarttest/testcases.go
@@ -1,0 +1,160 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package quickstarttest
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go/modules/compose"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+const (
+	sentItemsThreshold = 50.0
+)
+
+type testCase struct {
+	metricName string
+	exporter   string
+	threshold  float64
+}
+
+var testCases = []testCase{
+	{metricName: "otelcol_exporter_sent_spans", exporter: "googlecloud", threshold: sentItemsThreshold},
+	{metricName: "otelcol_exporter_sent_log_records", exporter: "googlecloud", threshold: sentItemsThreshold},
+	{metricName: "otelcol_exporter_sent_metric_points", exporter: "googlemanagedprometheus", threshold: sentItemsThreshold},
+}
+
+// InstrumentationQuickstartTest runs the instrumentation quickstart docker compose setup in
+// the quickstartRoot directory and verifies that metrics, logs, and traces are successfully
+// sent from the collector to GCP.
+//
+// Respects a COMPOSE_OVERRIDE_FILE environment variable set to a comma-separated list of paths
+// to additional compose files to include.
+func InstrumentationQuickstartTest(t *testing.T, quickstartRoot string) {
+	ctx := context.Background()
+	composeStack := composeUp(ctx, t, quickstartRoot)
+
+	// Let the docker compose app run until some spans/logs/metrics are sent to GCP
+	t.Logf("Compose stack is up, waiting for prometheus metrics indicating successful export")
+
+	// Check the collector's self-observability prometheus metrics to see that exports to GCP were successful.
+	for _, tc := range testCases {
+		t.Run(tc.metricName, func(t *testing.T) {
+			require.EventuallyWithT(
+				t,
+				func(collect *assert.CollectT) {
+					promMetrics, err := getPromMetrics(ctx, composeStack)
+					if !assert.NoError(collect, err) {
+						return
+					}
+					verifyPromMetric(collect, promMetrics, tc)
+				},
+				time.Minute*2, // wait for up to
+				time.Second,   // check at interval
+			)
+		})
+	}
+}
+
+func composeUp(ctx context.Context, t *testing.T, quickstartRoot string) compose.ComposeStack {
+	composeFiles := []string{filepath.Join(quickstartRoot, "docker-compose.yaml")}
+	if composeOverrideFile := os.Getenv("COMPOSE_OVERRIDE_FILE"); composeOverrideFile != "" {
+		composeFiles = append(composeFiles, strings.Split(composeOverrideFile, ",")...)
+	}
+
+	var (
+		composeStack compose.ComposeStack
+		err          error
+	)
+	composeStack, err = compose.NewDockerCompose(composeFiles...)
+	require.NoError(t, err)
+
+	require.NoError(t, err)
+	composeStack = composeStack.WithOsEnv().
+		WaitForService("app", wait.ForHTTP("/single").WithPort("8080")).
+		WaitForService("otelcol", wait.ForHTTP("/metrics").WithPort("8888"))
+
+	t.Cleanup(func() {
+		require.NoError(t, composeStack.Down(ctx, compose.RemoveOrphans(true)))
+	})
+	require.NoError(t, composeStack.Up(ctx))
+	return composeStack
+}
+
+func getPromMetrics(ctx context.Context, composeStack compose.ComposeStack) (map[string]*dto.MetricFamily, error) {
+	promUri, err := getPromEndpoint(ctx, composeStack)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.Get(promUri)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var parser expfmt.TextParser
+	parsed, err := parser.TextToMetricFamilies(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return parsed, nil
+}
+
+func getPromEndpoint(ctx context.Context, composeStack compose.ComposeStack) (string, error) {
+	collectorContainer, err := composeStack.ServiceContainer(ctx, "otelcol")
+	if err != nil {
+		return "", err
+	}
+	collectorHost, err := collectorContainer.Host(ctx)
+	if err != nil {
+		return "", err
+	}
+	collectorPort, err := collectorContainer.MappedPort(ctx, "8888")
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("http://%s:%s/metrics", collectorHost, collectorPort.Port()), nil
+}
+
+func verifyPromMetric(t assert.TestingT, promMetrics map[string]*dto.MetricFamily, tc testCase) {
+	if !assert.Contains(t, promMetrics, tc.metricName, "prometheus metrics do not contain %v:\n%v", tc.metricName, promMetrics) {
+		return
+	}
+	mf := promMetrics[tc.metricName]
+
+	for _, metric := range mf.Metric {
+		for _, labelPair := range metric.GetLabel() {
+			if labelPair.GetName() == "exporter" && labelPair.GetValue() == tc.exporter {
+				value := metric.GetCounter().GetValue()
+				assert.Greater(t, value, tc.threshold, "Metric %v was expected to have value > %v, got %v", metric, sentItemsThreshold, value)
+				return
+			}
+		}
+	}
+	assert.Fail(t, "Could not find a metric sample for exporter=%v, got metrics %v", tc.exporter, mf)
+}

--- a/quickstarttest/testcases_test.go
+++ b/quickstarttest/testcases_test.go
@@ -1,0 +1,154 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package quickstarttest
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/common/expfmt"
+	"github.com/stretchr/testify/require"
+)
+
+type MockT struct {
+	Failed  bool
+	Message string
+}
+
+func (t *MockT) Errorf(format string, args ...any) {
+	t.Failed = true
+	t.Message = fmt.Sprintf(format, args...)
+}
+
+func TestVerifyPromMetric(t *testing.T) {
+	tcs := []struct {
+		name       string
+		textFormat string
+		testCase   testCase
+		expectFail bool
+	}{
+		{
+			name: "metric is above threshold pass",
+			textFormat: `
+			# HELP otelcol_exporter_sent_log_records Number of log record successfully sent to destination.
+			# TYPE otelcol_exporter_sent_log_records counter
+			otelcol_exporter_sent_log_records{exporter="googlecloud"} 631
+			`,
+			testCase: testCase{
+				exporter:   "googlecloud",
+				metricName: "otelcol_exporter_sent_log_records",
+				threshold:  100,
+			},
+		},
+		{
+			name: "metric is below threshold fail",
+			textFormat: `
+			# HELP otelcol_exporter_sent_log_records Number of log record successfully sent to destination.
+			# TYPE otelcol_exporter_sent_log_records counter
+			otelcol_exporter_sent_log_records{exporter="googlecloud"} 1
+			`,
+			expectFail: true,
+			testCase: testCase{
+				exporter:   "googlecloud",
+				metricName: "otelcol_exporter_sent_log_records",
+				threshold:  100,
+			},
+		},
+		{
+			name:       "metric is not present fail",
+			textFormat: ``,
+			testCase: testCase{
+				exporter:   "googlecloud",
+				metricName: "otelcol_exporter_sent_log_records",
+				threshold:  100,
+			},
+			expectFail: true,
+		},
+		{
+			name: "exporter is not present fail",
+			textFormat: `
+			# HELP otelcol_exporter_sent_log_records Number of log record successfully sent to destination.
+			# TYPE otelcol_exporter_sent_log_records counter
+			otelcol_exporter_sent_log_records{exporter="googlecloud"} 631
+			`,
+			expectFail: true,
+			testCase: testCase{
+				exporter:   "fooexporter",
+				metricName: "otelcol_exporter_sent_log_records",
+				threshold:  100,
+			},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			mockT := &MockT{}
+			var parser expfmt.TextParser
+			actual, err := parser.TextToMetricFamilies(strings.NewReader(tc.textFormat))
+			require.NoError(t, err)
+			verifyPromMetric(mockT, actual, tc.testCase)
+
+			if tc.expectFail {
+				require.True(t, mockT.Failed, "Expected test case to fail but passed")
+			} else {
+				require.Falsef(t, mockT.Failed, "Expected test case to pass but failed with: %v", mockT.Message)
+			}
+		})
+	}
+}
+
+func TestVerifyPromRealTestCasesSuccess(t *testing.T) {
+	var parser expfmt.TextParser
+	// Taken from a real run of the quickstart
+	actual, err := parser.TextToMetricFamilies(strings.NewReader(`
+	# HELP otelcol_exporter_sent_log_records Number of log record successfully sent to destination.
+	# TYPE otelcol_exporter_sent_log_records counter
+	otelcol_exporter_sent_log_records{exporter="googlecloud",service_instance_id="cc2396b4-e313-4c5a-8c35-0cb221a02fa8",service_name="otelcol-contrib",service_version="0.107.0"} 437
+	# HELP otelcol_exporter_sent_metric_points Number of metric points successfully sent to destination.
+	# TYPE otelcol_exporter_sent_metric_points counter
+	otelcol_exporter_sent_metric_points{exporter="googlemanagedprometheus",service_instance_id="cc2396b4-e313-4c5a-8c35-0cb221a02fa8",service_name="otelcol-contrib",service_version="0.107.0"} 333
+	# HELP otelcol_exporter_sent_spans Number of spans successfully sent to destination.
+	# TYPE otelcol_exporter_sent_spans counter
+	otelcol_exporter_sent_spans{exporter="googlecloud",service_instance_id="cc2396b4-e313-4c5a-8c35-0cb221a02fa8",service_name="otelcol-contrib",service_version="0.107.0"} 499
+	`))
+	require.NoError(t, err)
+
+	for _, tc := range testCases {
+		verifyPromMetric(t, actual, tc)
+	}
+}
+
+func TestVerifyPromRealTestCasesFails(t *testing.T) {
+	var parser expfmt.TextParser
+	// Taken from a real run of the quickstart
+	actual, err := parser.TextToMetricFamilies(strings.NewReader(`
+	# HELP otelcol_exporter_sent_log_records Number of log record successfully sent to destination.
+	# TYPE otelcol_exporter_sent_log_records counter
+	otelcol_exporter_sent_log_records{exporter="googlecloud",service_instance_id="cc2396b4-e313-4c5a-8c35-0cb221a02fa8",service_name="otelcol-contrib",service_version="0.107.0"} 0
+	# HELP otelcol_exporter_sent_metric_points Number of metric points successfully sent to destination.
+	# TYPE otelcol_exporter_sent_metric_points counter
+	otelcol_exporter_sent_metric_points{exporter="googlemanagedprometheus",service_instance_id="cc2396b4-e313-4c5a-8c35-0cb221a02fa8",service_name="otelcol-contrib",service_version="0.107.0"} 0
+	# HELP otelcol_exporter_sent_spans Number of spans successfully sent to destination.
+	# TYPE otelcol_exporter_sent_spans counter
+	otelcol_exporter_sent_spans{exporter="googlecloud",service_instance_id="cc2396b4-e313-4c5a-8c35-0cb221a02fa8",service_name="otelcol-contrib",service_version="0.107.0"} 0
+	`))
+	require.NoError(t, err)
+
+	mockT := &MockT{}
+	for _, tc := range testCases {
+		verifyPromMetric(mockT, actual, tc)
+	}
+	require.True(t, mockT.Failed, "Expected test case to fail but passed")
+}


### PR DESCRIPTION
Split from https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/pull/364 but tested there

This lib provides a way to test the docker compose instrumentation quickstarts we have. The plan is to add a small go test which calls this lib in each of:

- [ ] https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/tree/main/examples/instrumentation-quickstart
- [ ] https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/blob/main/samples/instrumentation-quickstart
- [ ] https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/tree/main/samples/instrumentation-quickstart
- [ ] https://github.com/GoogleCloudPlatform/golang-samples/tree/main/opentelemetry/instrumentation