### PR TITLE
feat: add configurable smoke test runner with CLI argument support

### DIFF
--- a/e2etesting/e2e_testing.go
+++ b/e2etesting/e2e_testing.go
@@ -134,6 +134,8 @@ type Args struct {
 	// resources created for debugging. If not provided, we generate a hex
 	// string.
 	TestRunID string `arg:"--test-run-id,env:TEST_RUN_ID" help:"Optional test run id to use to partition terraform resources"`
+
+	CollectorSmokeTests []string `arg:"--collector-smoke-tests,separate" help:"Smoke tests to run (e.g. --collector-smoke-tests metrics --collector-smoke-tests logs)"`
 }
 
 type Cleanup func()

--- a/e2etestrunner_collector/main_test.go
+++ b/e2etestrunner_collector/main_test.go
@@ -21,6 +21,9 @@ var (
 
 func TestMain(m *testing.M) {
 	logger, ctx := e2etesting.InitTestMain(&args, setuptf.ApplyPersistentCollector)
+	if len(args.CollectorSmokeTests) == 0 {
+		args.CollectorSmokeTests = []string{"metrics", "logs", "traces"}
+	}
 	resourceFilter = fmt.Sprintf("otelcol_google_e2e:%s", args.TestRunID)
 	var setupFunc e2etesting.SetupCollectorFunc
 	switch {

--- a/e2etestrunner_collector/smoke_test.go
+++ b/e2etestrunner_collector/smoke_test.go
@@ -24,7 +24,13 @@ const (
 	queryMaxAttempts     = 3
 )
 
-func TestMetrics(t *testing.T) {
+var smokeTests = map[string]func(t *testing.T){
+	"metrics": runMetricsTest,
+	"logs":    runLoggingTest,
+	"traces":  runTracesTest,
+}
+
+func runMetricsTest(t *testing.T) {
 	ctx := context.Background()
 	c, err := monitoring.NewMetricClient(ctx)
 	if err != nil {
@@ -82,7 +88,7 @@ func TestMetrics(t *testing.T) {
 	fmt.Printf("Found representative metric: %v\n", tsList[0].Metric)
 }
 
-func TestLogging(t *testing.T) {
+func runLoggingTest(t *testing.T) {
 	ctx := context.Background()
 	client, err := logadmin.NewClient(ctx, args.ProjectID)
 	if err != nil {
@@ -113,7 +119,7 @@ func TestLogging(t *testing.T) {
 	fmt.Println(fmt.Sprintf("Entry found: %v", entry))
 }
 
-func TestTraces(t *testing.T) {
+func runTracesTest(t *testing.T) {
 	ctx := context.Background()
 	cloudService, err := cloudtrace.NewService(ctx)
 	if err != nil {
@@ -131,4 +137,14 @@ func TestTraces(t *testing.T) {
 		t.Errorf(fmt.Sprintf("Could not find traces with resource attribute: %s", resourceFilter))
 	}
 	fmt.Println(fmt.Sprintf("Found traces with resource attribute%s", resourceFilter))
+}
+
+func TestSmoke(t *testing.T) {
+	for _, name := range args.CollectorSmokeTests {
+		if run, ok := smokeTests[name]; ok {
+			t.Run(name, run)
+		} else {
+			t.Errorf("Unknown smoke test: %s", name)
+		}
+	}
 }


### PR DESCRIPTION
Some collectors don't have export logs or traces, this PR allows you to select which tests you want to run. 

b/493887747