### PR TITLE
Use exponential backoff and longer duration for trace retries

### DIFF
--- a/cloudbuild-e2e-gae-standard.yaml
+++ b/cloudbuild-e2e-gae-standard.yaml
@@ -44,7 +44,7 @@ steps:
         cd opentelemetry-operations-go
         LATEST_TAG=$$(git describe --tags $$(git rev-list --tags --max-count=1))
         git checkout $$LATEST_TAG
-  - name: golang:1.24.2
+  - name: golang:1.25.5
     id: zip-code
     entrypoint: /bin/bash
     args:

--- a/e2etesting/e2e_testing.go
+++ b/e2etesting/e2e_testing.go
@@ -126,9 +126,10 @@ type Args struct {
 	CloudFunctionsGen2   *CloudFunctionsGen2Cmd   `arg:"subcommand:cloud-functions-gen2" help:"Deploy the test server on Cloud Function (2nd Gen) and execute tests"`
 
 	CmdWithProjectId
-	GoTestFlags        string        `help:"go test flags to pass through, e.g. --gotestflags='-test.v'"`
-	HealthCheckTimeout time.Duration `arg:"--health-check-timeout" help:"A duration (e.g. 5m) to wait for the test server health check. Default is 2m." default:"15m"`
-
+	GoTestFlags         string        `help:"go test flags to pass through, e.g. --gotestflags='-test.v'"`
+	HealthCheckTimeout  time.Duration `arg:"--health-check-timeout" help:"A duration (e.g. 5m) to wait for the test server health check. Default is 2m." default:"15m"`
+	TraceBackoffInitial time.Duration `arg:"--trace-backoff-initial" help:"Initial exponential backoff duration for trace retries" default:"1s"`
+	TraceBackoffTotal   time.Duration `arg:"--trace-backoff-total" help:"Total maximum duration for trace retries" default:"60s"`
 	// This is used in a new terraform workspace's name and in the GCP resources
 	// we create. Pass the GCB build ID in CI to get the build id formatted into
 	// resources created for debugging. If not provided, we generate a hex

--- a/e2etestrunner/trace_test.go
+++ b/e2etestrunner/trace_test.go
@@ -75,8 +75,8 @@ func getTraceWithRetry(
 	traceId string,
 ) *cloudtrace.Trace {
 	var trace *cloudtrace.Trace
-	backoff, _ := retry.NewConstant(1 * time.Second)
-	backoff = retry.WithMaxDuration(time.Second*10, backoff)
+	backoff, _ := retry.NewExponential(args.TraceBackoffInitial)
+	backoff = retry.WithMaxDuration(args.TraceBackoffTotal, backoff)
 	err := retry.Do(ctx, backoff, func(ctx context.Context) error {
 		var err error
 		trace, err = cloudtraceService.Projects.Traces.Get(args.ProjectID, traceId).Context(ctx).Do()


### PR DESCRIPTION
Implements plan 1 to fix flaky e2e tests by using exponential backoff and increasing timeout to 60s.