### PR TITLE
Improve logging in TestBasicTrace to show unexpected labels

### DIFF
--- a/cloudbuild-e2e-gae-standard.yaml
+++ b/cloudbuild-e2e-gae-standard.yaml
@@ -44,7 +44,7 @@ steps:
         cd opentelemetry-operations-go
         LATEST_TAG=$$(git describe --tags $$(git rev-list --tags --max-count=1))
         git checkout $$LATEST_TAG
-  - name: golang:1.24.2
+  - name: golang:1.25.5
     id: zip-code
     entrypoint: /bin/bash
     args:
@@ -64,7 +64,7 @@ steps:
     env: ["PROJECT_ID=$PROJECT_ID"]
     args:
       - gae-standard
-      - --runtime=go124
+      - --runtime=go125
       - --appsource=/workspace/opentelemetry-operations-go/e2e-test-server/appsource.zip
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs

--- a/e2etesting/e2e_testing.go
+++ b/e2etesting/e2e_testing.go
@@ -126,9 +126,10 @@ type Args struct {
 	CloudFunctionsGen2   *CloudFunctionsGen2Cmd   `arg:"subcommand:cloud-functions-gen2" help:"Deploy the test server on Cloud Function (2nd Gen) and execute tests"`
 
 	CmdWithProjectId
-	GoTestFlags        string        `help:"go test flags to pass through, e.g. --gotestflags='-test.v'"`
-	HealthCheckTimeout time.Duration `arg:"--health-check-timeout" help:"A duration (e.g. 5m) to wait for the test server health check. Default is 2m." default:"15m"`
-
+	GoTestFlags         string        `help:"go test flags to pass through, e.g. --gotestflags='-test.v'"`
+	HealthCheckTimeout  time.Duration `arg:"--health-check-timeout" help:"A duration (e.g. 5m) to wait for the test server health check. Default is 2m." default:"15m"`
+	TraceBackoffInitial time.Duration `arg:"--trace-backoff-initial" help:"Initial exponential backoff duration for trace retries" default:"1s"`
+	TraceBackoffTotal   time.Duration `arg:"--trace-backoff-total" help:"Total maximum duration for trace retries" default:"60s"`
 	// This is used in a new terraform workspace's name and in the GCP resources
 	// we create. Pass the GCB build ID in CI to get the build id formatted into
 	// resources created for debugging. If not provided, we generate a hex

--- a/e2etestrunner/trace_test.go
+++ b/e2etestrunner/trace_test.go
@@ -125,7 +125,7 @@ func TestBasicTrace(t *testing.T) {
 	)
 
 	// Ignore-able labels (resource, instrumentation library)
-	numLabels := 0
+	var nonResourceLabels []string
 	for key := range span.Labels {
 		if strings.HasPrefix(key, "g.co/r/") {
 			continue
@@ -138,11 +138,15 @@ func TestBasicTrace(t *testing.T) {
 		if strings.HasPrefix(key, "k8s.") {
 			continue
 		}
-		numLabels += 1
+		// Ignore specific GCP resource labels that are known to be added by the exporter.
+		if key == "gcp.project_id" {
+			continue
+		}
+		nonResourceLabels = append(nonResourceLabels, key)
 	}
 
-	if numLabels != 2 {
-		t.Fatalf("Expected exactly 2 non-resource labels, got %v", numLabels)
+	if len(nonResourceLabels) != 2 {
+		t.Fatalf("Expected exactly 2 non-resource labels, got %v. Labels found: %v", len(nonResourceLabels), nonResourceLabels)
 	}
 
 	labelCases := []struct {

--- a/e2etestrunner/trace_test.go
+++ b/e2etestrunner/trace_test.go
@@ -75,8 +75,8 @@ func getTraceWithRetry(
 	traceId string,
 ) *cloudtrace.Trace {
 	var trace *cloudtrace.Trace
-	backoff, _ := retry.NewConstant(1 * time.Second)
-	backoff = retry.WithMaxDuration(time.Second*10, backoff)
+	backoff, _ := retry.NewExponential(args.TraceBackoffInitial)
+	backoff = retry.WithMaxDuration(args.TraceBackoffTotal, backoff)
 	err := retry.Do(ctx, backoff, func(ctx context.Context) error {
 		var err error
 		trace, err = cloudtraceService.Projects.Traces.Get(args.ProjectID, traceId).Context(ctx).Do()


### PR DESCRIPTION
Some changes to get tests passing again.

- Ignore `gcp.project_id` label in basicTrace scenario. I think we're now seeing this occasionally as a result of some internal changes.

  Also improve logging when we get unexpected labels.
- Also use exponential backoff and longer duration for trace retries. I exposed this with a flag.