### PR TITLE
Durable async cleanup to speed up tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ terraform*
 
 go.work
 go.work.sum
+
+# Ignore nested jj workspace
+concurrent_task/

--- a/cloudbuild-cleanup.yaml
+++ b/cloudbuild-cleanup.yaml
@@ -1,0 +1,13 @@
+steps:
+  - name: $_TEST_RUNNER_IMAGE
+    id: cleanup
+    dir: /
+    timeout: 600s
+    args:
+      - cleanup
+      - --environment=$_E2E_ENVIRONMENT
+      - --project-id=$PROJECT_ID
+      - --test-run-id=$_TEST_RUN_ID
+
+substitutions:
+  _TEST_RUN_ID: $BUILD_ID

--- a/cloudbuild-e2e-cloud-functions-gen2.yaml
+++ b/cloudbuild-e2e-cloud-functions-gen2.yaml
@@ -61,14 +61,19 @@ steps:
     id: run-tests-cloudfunctions
     dir: /
     timeout: 1800s
-    env: ["PROJECT_ID=$PROJECT_ID"]
+    env: ["PROJECT_ID=$PROJECT_ID", "TEST_RUN_ID=$BUILD_ID"]
     args:
       - cloud-functions-gen2
       - --runtime=go125
       - --functionsource=/workspace/opentelemetry-operations-go/e2e-test-server/cloud_functions/function-source.zip
       - --entrypoint=HandleCloudFunction
+      - --skip-cleanup
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
   _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:${SHORT_SHA}
   _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-go-e2e-test-server:${SHORT_SHA}
+
+options:
+  # Notify for Cloud Build async cleanup trigger
+  pubsubTopic: projects/opentelemetry-ops-e2e/topics/e2e-cleanup

--- a/cloudbuild-e2e-cloud-run.yaml
+++ b/cloudbuild-e2e-cloud-run.yaml
@@ -39,12 +39,17 @@ steps:
     id: run-tests-cloudrun
     dir: /
     timeout: 10m
-    env: ["PROJECT_ID=$PROJECT_ID"]
+    env: ["PROJECT_ID=$PROJECT_ID", "TEST_RUN_ID=$BUILD_ID"]
     args:
       - cloud-run
       - --image=$_TEST_SERVER_IMAGE
+      - --skip-cleanup
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
   _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:${SHORT_SHA}
   _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-go-e2e-test-server:${SHORT_SHA}
+
+options:
+  # Notify for Cloud Build async cleanup trigger
+  pubsubTopic: projects/opentelemetry-ops-e2e/topics/e2e-cleanup

--- a/cloudbuild-e2e-gae-standard.yaml
+++ b/cloudbuild-e2e-gae-standard.yaml
@@ -61,13 +61,18 @@ steps:
     id: run-tests-gae-standard
     dir: /
     timeout: 10m
-    env: ["PROJECT_ID=$PROJECT_ID"]
+    env: ["PROJECT_ID=$PROJECT_ID", "TEST_RUN_ID=$BUILD_ID"]
     args:
       - gae-standard
       - --runtime=go125
       - --appsource=/workspace/opentelemetry-operations-go/e2e-test-server/appsource.zip
+      - --skip-cleanup
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
   _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:${SHORT_SHA}
   _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-go-e2e-test-server:${SHORT_SHA}
+
+options:
+  # Notify for Cloud Build async cleanup trigger
+  pubsubTopic: projects/opentelemetry-ops-e2e/topics/e2e-cleanup

--- a/cloudbuild-e2e-gae.yaml
+++ b/cloudbuild-e2e-gae.yaml
@@ -39,13 +39,18 @@ steps:
     id: run-tests-gae
     dir: /
     timeout: 10m
-    env: ["PROJECT_ID=$PROJECT_ID"]
+    env: ["PROJECT_ID=$PROJECT_ID", "TEST_RUN_ID=$BUILD_ID"]
     args:
       - gae
       - --image=$_TEST_SERVER_IMAGE
       - --runtime=go125
+      - --skip-cleanup
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
   _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:${SHORT_SHA}
   _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-go-e2e-test-server:${SHORT_SHA}
+
+options:
+  # Notify for Cloud Build async cleanup trigger
+  pubsubTopic: projects/opentelemetry-ops-e2e/topics/e2e-cleanup

--- a/cloudbuild-e2e-gce.yaml
+++ b/cloudbuild-e2e-gce.yaml
@@ -39,12 +39,17 @@ steps:
     id: run-tests-gce
     dir: /
     timeout: 10m
-    env: ["PROJECT_ID=$PROJECT_ID"]
+    env: ["PROJECT_ID=$PROJECT_ID", "TEST_RUN_ID=$BUILD_ID"]
     args:
       - gce
       - --image=$_TEST_SERVER_IMAGE
+      - --skip-cleanup
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
   _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:${SHORT_SHA}
   _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-go-e2e-test-server:${SHORT_SHA}
+
+options:
+  # Notify for Cloud Build async cleanup trigger
+  pubsubTopic: projects/opentelemetry-ops-e2e/topics/e2e-cleanup

--- a/cloudbuild-e2e-gke.yaml
+++ b/cloudbuild-e2e-gke.yaml
@@ -39,12 +39,17 @@ steps:
     id: run-tests-gke
     dir: /
     timeout: 10m
-    env: ["PROJECT_ID=$PROJECT_ID"]
+    env: ["PROJECT_ID=$PROJECT_ID", "TEST_RUN_ID=$BUILD_ID"]
     args:
       - gke
       - --image=$_TEST_SERVER_IMAGE
+      - --skip-cleanup
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
   _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:${SHORT_SHA}
   _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-go-e2e-test-server:${SHORT_SHA}
+
+options:
+  # Notify for Cloud Build async cleanup trigger
+  pubsubTopic: projects/opentelemetry-ops-e2e/topics/e2e-cleanup

--- a/e2etesting/e2e_testing.go
+++ b/e2etesting/e2e_testing.go
@@ -172,8 +172,7 @@ func InitTestMain(args *Args, applyPersistent ApplyPersistentFunc) (*log.Logger,
 
 	// Handle cleanup subcommand
 	if args.Cleanup != nil {
-		tfDir := "tf/destroy"
-		err := setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, tfDir, logger)
+		err := setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, logger)
 		if err != nil {
 			logger.Panic(err)
 		}

--- a/e2etesting/e2e_testing.go
+++ b/e2etesting/e2e_testing.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GoogleCloudPlatform/opentelemetry-operations-e2e-testing/e2etesting/setuptf"
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-e2e-testing/e2etestrunner/testclient"
 	"github.com/alexflint/go-arg"
 )
@@ -106,11 +107,15 @@ type CloudFunctionsGen2Cmd struct {
 	FunctionSource string `arg:"required" help:"The full path of the zip file that contains the code source that needs to run within the CloudFunction"`
 }
 
+type CleanupCmd struct{}
+
 type Args struct {
 	// This subcommand is a special case, it doesn't run any tests. It just
 	// applies the persistent resources which are used across tests. See
 	// tf/persistent/README.md for details on what is in there.
 	ApplyPersistent *ApplyPersistent `arg:"subcommand:apply-persistent" help:"Terraform apply the resources in tf/persistent and exit (does not run tests)."`
+
+	Cleanup              *CleanupCmd              `arg:"subcommand:cleanup" help:"Clean up resources for a test run"`
 
 	Local                *LocalCmd                `arg:"subcommand:local" help:"Deploy the test server locally with docker and execute tests"`
 	Gke                  *GkeCmd                  `arg:"subcommand:gke" help:"Deploy the test server on GKE and execute tests"`
@@ -135,6 +140,7 @@ type Args struct {
 	// resources created for debugging. If not provided, we generate a hex
 	// string.
 	TestRunID string `arg:"--test-run-id,env:TEST_RUN_ID" help:"Optional test run id to use to partition terraform resources"`
+	SkipCleanup bool   `arg:"--skip-cleanup" help:"Skip automatic cleanup after tests (default: false). If enabled, you must run the 'cleanup' subcommand manually or via trigger."`
 }
 
 type Cleanup func()
@@ -163,6 +169,16 @@ func InitTestMain(args *Args, applyPersistent ApplyPersistentFunc) (*log.Logger,
 	// Need a logger just for TestMain() before testing.T is available
 	logger := log.New(os.Stdout, "TestMain: ", log.LstdFlags|log.Lshortfile)
 	ctx := context.Background()
+
+	// Handle cleanup subcommand
+	if args.Cleanup != nil {
+		tfDir := "tf/destroy"
+		err := setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, tfDir, logger)
+		if err != nil {
+			logger.Panic(err)
+		}
+		return nil, nil, true
+	}
 
 	// Handle special case of just creating persistent resources
 	if args.ApplyPersistent != nil {

--- a/e2etesting/setuptf/setuptf.go
+++ b/e2etesting/setuptf/setuptf.go
@@ -69,9 +69,8 @@ func initCommand(ctx context.Context, projectID string) *exec.Cmd {
 	)
 }
 
-// Runs the sequence of terraform commands most environemnts need, returns the
-// output bytes of `terraform output -json` and a cleanup function to teardown
-// the created resources.
+// Runs the sequence of terraform commands most environments need, returns the
+// parsed PubsubInfo from `terraform output -json`.
 //
 // 1. Run terraform init
 // 2. Create a new terraform workspace for the test run ID
@@ -86,34 +85,16 @@ func SetupTf(
 	tfDir string, // the Dir to set when running terraform commands in e.g. tf/gke
 	tfVars map[string]string, // key-values for terraform input vars to send to terraform
 	logger *log.Logger,
-) (*PubsubInfo, func(), error) {
+) (*PubsubInfo, error) {
 	tfVarArgs := tfVarMapToArgs(projectID, tfVars)
 	cmd := initCommand(ctx, projectID)
 	cmd.Args = append(cmd.Args, tfVarArgs...)
 	cmd.Dir = tfDir
 	if err := runWithOutput(cmd, logger); err != nil {
-		return nil, func() {}, err
+		return nil, err
 	}
 
 	logger.Printf("Running %s with image: %s\n", tfDir, tfVars["image"])
-
-	cleanup := func() {
-		defer deleteWorkspace(ctx, testRunID, tfDir, logger)
-
-		// Run terraform destroy
-		cmd = exec.CommandContext(
-			ctx,
-			"terraform",
-			"destroy",
-			"-input=false",
-			"-auto-approve",
-		)
-		cmd.Args = append(cmd.Args, tfVarArgs...)
-		cmd.Dir = tfDir
-		if err := runWithOutput(cmd, logger); err != nil {
-			logger.Panic(err)
-		}
-	}
 
 	// Create new terraform workspace
 	cmd = exec.CommandContext(ctx, "terraform", "workspace", "new", testRunID)
@@ -124,7 +105,7 @@ func SetupTf(
 		cmd.Dir = tfDir
 
 		if err := runWithOutput(cmd, logger); err != nil {
-			return nil, cleanup, err
+			return nil, err
 		}
 	}
 
@@ -139,7 +120,7 @@ func SetupTf(
 	cmd.Args = append(cmd.Args, tfVarArgs...)
 	cmd.Dir = tfDir
 	if err := runWithOutput(cmd, logger); err != nil {
-		return nil, cleanup, err
+		return nil, err
 	}
 
 	// Run terraform output
@@ -148,14 +129,14 @@ func SetupTf(
 	out, err := cmd.Output()
 	if err != nil {
 		logger.Println(err)
-		return nil, cleanup, err
+		return nil, err
 	}
 
 	tfOutput := &tfOutput{}
 	if err := json.Unmarshal(out, tfOutput); err != nil {
-		return nil, cleanup, err
+		return nil, err
 	}
-	return &tfOutput.PubsubInfoWrapper.Value, cleanup, nil
+	return &tfOutput.PubsubInfoWrapper.Value, nil
 }
 
 func ApplyPersistent(
@@ -254,4 +235,48 @@ func tfVarMapToArgs(
 		tfVarArgs = append(tfVarArgs, fmt.Sprintf("-var=%v=%v", k, v))
 	}
 	return tfVarArgs
+}
+
+// CleanupTf runs terraform destroy and deletes the workspace.
+func CleanupTf(
+	ctx context.Context,
+	projectID string,
+	testRunID string,
+	tfDir string,
+	logger *log.Logger,
+) error {
+	tfVarArgs := []string{fmt.Sprintf("-var=project_id=%s", projectID)}
+	cmd := initCommand(ctx, projectID)
+	cmd.Dir = tfDir
+	if err := runWithOutput(cmd, logger); err != nil {
+		logger.Printf("error cleaning up terraform (init) in %s: %v", tfDir, err)
+		return err
+	}
+
+	// Switch to target workspace
+	cmd = exec.CommandContext(ctx, "terraform", "workspace", "select", testRunID)
+	cmd.Dir = tfDir
+	if err := runWithOutput(cmd, logger); err != nil {
+		logger.Printf("error cleaning up terraform (workspace select %s) in %s: %v", testRunID, tfDir, err)
+		return err
+	}
+
+	// Run terraform destroy
+	cmd = exec.CommandContext(
+		ctx,
+		"terraform",
+		"destroy",
+		"-input=false",
+		"-auto-approve",
+	)
+	cmd.Args = append(cmd.Args, tfVarArgs...)
+	cmd.Dir = tfDir
+	if err := runWithOutput(cmd, logger); err != nil {
+		logger.Printf("error cleaning up terraform (destroy) in %s: %v", tfDir, err)
+		return err
+	}
+
+	deleteWorkspace(ctx, testRunID, tfDir, logger)
+
+	return nil
 }

--- a/e2etesting/setuptf/setuptf.go
+++ b/e2etesting/setuptf/setuptf.go
@@ -242,9 +242,9 @@ func CleanupTf(
 	ctx context.Context,
 	projectID string,
 	testRunID string,
-	tfDir string,
 	logger *log.Logger,
 ) error {
+	const tfDir = "tf/destroy"
 	tfVarArgs := []string{fmt.Sprintf("-var=project_id=%s", projectID)}
 	cmd := initCommand(ctx, projectID)
 	cmd.Dir = tfDir

--- a/e2etestrunner/main_test.go
+++ b/e2etestrunner/main_test.go
@@ -57,7 +57,12 @@ func TestMain(m *testing.M) {
 	}
 	client, cleanup, err := setupFunc(ctx, &args, logger)
 
-	defer cleanup()
+	if !args.SkipCleanup {
+		defer cleanup()
+	} else {
+		logger.Println("Skipping auto-cleanup (explicitly requested)")
+	}
+
 	if err != nil {
 		logger.Panic(err)
 	}

--- a/e2etestrunner/setup_cloud_functions_gen2.go
+++ b/e2etestrunner/setup_cloud_functions_gen2.go
@@ -33,7 +33,10 @@ func SetupCloudFunctionsGen2(
 	args *e2etesting.Args,
 	logger *log.Logger,
 ) (*testclient.Client, e2etesting.Cleanup, error) {
-	pubsubInfo, cleanupTf, err := setuptf.SetupTf(
+	cleanup := func() {
+		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, "tf/destroy", logger)
+	}
+	pubsubInfo, err := setuptf.SetupTf(
 		ctx,
 		args.ProjectID,
 		args.TestRunID,
@@ -46,9 +49,9 @@ func SetupCloudFunctionsGen2(
 		logger,
 	)
 	if err != nil {
-		return nil, cleanupTf, err
+		return nil, cleanup, err
 	}
 
 	client, err := testclient.New(ctx, args.ProjectID, pubsubInfo)
-	return client, cleanupTf, err
+	return client, cleanup, err
 }

--- a/e2etestrunner/setup_cloud_functions_gen2.go
+++ b/e2etestrunner/setup_cloud_functions_gen2.go
@@ -34,7 +34,7 @@ func SetupCloudFunctionsGen2(
 	logger *log.Logger,
 ) (*testclient.Client, e2etesting.Cleanup, error) {
 	cleanup := func() {
-		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, "tf/destroy", logger)
+		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, logger)
 	}
 	pubsubInfo, err := setuptf.SetupTf(
 		ctx,

--- a/e2etestrunner/setup_cloud_run.go
+++ b/e2etestrunner/setup_cloud_run.go
@@ -33,7 +33,10 @@ func SetupCloudRun(
 	args *e2etesting.Args,
 	logger *log.Logger,
 ) (*testclient.Client, e2etesting.Cleanup, error) {
-	pubsubInfo, cleanupTf, err := setuptf.SetupTf(
+	cleanup := func() {
+		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, "tf/destroy", logger)
+	}
+	pubsubInfo, err := setuptf.SetupTf(
 		ctx,
 		args.ProjectID,
 		args.TestRunID,
@@ -44,9 +47,9 @@ func SetupCloudRun(
 		logger,
 	)
 	if err != nil {
-		return nil, cleanupTf, err
+		return nil, cleanup, err
 	}
 
 	client, err := testclient.New(ctx, args.ProjectID, pubsubInfo)
-	return client, cleanupTf, err
+	return client, cleanup, err
 }

--- a/e2etestrunner/setup_cloud_run.go
+++ b/e2etestrunner/setup_cloud_run.go
@@ -34,7 +34,7 @@ func SetupCloudRun(
 	logger *log.Logger,
 ) (*testclient.Client, e2etesting.Cleanup, error) {
 	cleanup := func() {
-		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, "tf/destroy", logger)
+		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, logger)
 	}
 	pubsubInfo, err := setuptf.SetupTf(
 		ctx,

--- a/e2etestrunner/setupgae.go
+++ b/e2etestrunner/setupgae.go
@@ -30,7 +30,10 @@ func SetupGae(
 	args *e2etesting.Args,
 	logger *log.Logger,
 ) (*testclient.Client, e2etesting.Cleanup, error) {
-	pubsubInfo, cleanupTf, err := setuptf.SetupTf(
+	cleanup := func() {
+		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, "tf/destroy", logger)
+	}
+	pubsubInfo, err := setuptf.SetupTf(
 		ctx,
 		args.ProjectID,
 		args.TestRunID,
@@ -42,9 +45,9 @@ func SetupGae(
 		logger,
 	)
 	if err != nil {
-		return nil, cleanupTf, err
+		return nil, cleanup, err
 	}
 
 	client, err := testclient.New(ctx, args.ProjectID, pubsubInfo)
-	return client, cleanupTf, err
+	return client, cleanup, err
 }

--- a/e2etestrunner/setupgae.go
+++ b/e2etestrunner/setupgae.go
@@ -31,7 +31,7 @@ func SetupGae(
 	logger *log.Logger,
 ) (*testclient.Client, e2etesting.Cleanup, error) {
 	cleanup := func() {
-		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, "tf/destroy", logger)
+		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, logger)
 	}
 	pubsubInfo, err := setuptf.SetupTf(
 		ctx,

--- a/e2etestrunner/setupgaestandard.go
+++ b/e2etestrunner/setupgaestandard.go
@@ -31,7 +31,7 @@ func SetupGaeStandard(
 	logger *log.Logger,
 ) (*testclient.Client, e2etesting.Cleanup, error) {
 	cleanup := func() {
-		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, "tf/destroy", logger)
+		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, logger)
 	}
 	pubsubInfo, err := setuptf.SetupTf(
 		ctx,

--- a/e2etestrunner/setupgaestandard.go
+++ b/e2etestrunner/setupgaestandard.go
@@ -30,7 +30,10 @@ func SetupGaeStandard(
 	args *e2etesting.Args,
 	logger *log.Logger,
 ) (*testclient.Client, e2etesting.Cleanup, error) {
-	pubsubInfo, cleanupTf, err := setuptf.SetupTf(
+	cleanup := func() {
+		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, "tf/destroy", logger)
+	}
+	pubsubInfo, err := setuptf.SetupTf(
 		ctx,
 		args.ProjectID,
 		args.TestRunID,
@@ -43,9 +46,9 @@ func SetupGaeStandard(
 		logger,
 	)
 	if err != nil {
-		return nil, cleanupTf, err
+		return nil, cleanup, err
 	}
 
 	client, err := testclient.New(ctx, args.ProjectID, pubsubInfo)
-	return client, cleanupTf, err
+	return client, cleanup, err
 }

--- a/e2etestrunner/setupgce.go
+++ b/e2etestrunner/setupgce.go
@@ -33,7 +33,10 @@ func SetupGce(
 	args *e2etesting.Args,
 	logger *log.Logger,
 ) (*testclient.Client, e2etesting.Cleanup, error) {
-	pubsubInfo, cleanupTf, err := setuptf.SetupTf(
+	cleanup := func() {
+		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, "tf/destroy", logger)
+	}
+	pubsubInfo, err := setuptf.SetupTf(
 		ctx,
 		args.ProjectID,
 		args.TestRunID,
@@ -44,9 +47,9 @@ func SetupGce(
 		logger,
 	)
 	if err != nil {
-		return nil, cleanupTf, err
+		return nil, cleanup, err
 	}
 
 	client, err := testclient.New(ctx, args.ProjectID, pubsubInfo)
-	return client, cleanupTf, err
+	return client, cleanup, err
 }

--- a/e2etestrunner/setupgce.go
+++ b/e2etestrunner/setupgce.go
@@ -34,7 +34,7 @@ func SetupGce(
 	logger *log.Logger,
 ) (*testclient.Client, e2etesting.Cleanup, error) {
 	cleanup := func() {
-		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, "tf/destroy", logger)
+		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, logger)
 	}
 	pubsubInfo, err := setuptf.SetupTf(
 		ctx,

--- a/e2etestrunner/setupgke.go
+++ b/e2etestrunner/setupgke.go
@@ -34,7 +34,7 @@ func SetupGke(
 	logger *log.Logger,
 ) (*testclient.Client, e2etesting.Cleanup, error) {
 	cleanup := func() {
-		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, "tf/destroy", logger)
+		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, logger)
 	}
 	pubsubInfo, err := setuptf.SetupTf(
 		ctx,

--- a/e2etestrunner/setupgke.go
+++ b/e2etestrunner/setupgke.go
@@ -33,7 +33,10 @@ func SetupGke(
 	args *e2etesting.Args,
 	logger *log.Logger,
 ) (*testclient.Client, e2etesting.Cleanup, error) {
-	pubsubInfo, cleanupTf, err := setuptf.SetupTf(
+	cleanup := func() {
+		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, "tf/destroy", logger)
+	}
+	pubsubInfo, err := setuptf.SetupTf(
 		ctx,
 		args.ProjectID,
 		args.TestRunID,
@@ -44,9 +47,9 @@ func SetupGke(
 		logger,
 	)
 	if err != nil {
-		return nil, cleanupTf, err
+		return nil, cleanup, err
 	}
 
 	client, err := testclient.New(ctx, args.ProjectID, pubsubInfo)
-	return client, cleanupTf, err
+	return client, cleanup, err
 }

--- a/e2etestrunner/setuplocal.go
+++ b/e2etestrunner/setuplocal.go
@@ -16,7 +16,6 @@ package e2etestrunner
 
 import (
 	"context"
-	"fmt"
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-e2e-testing/e2etesting"
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-e2e-testing/e2etesting/setuptf"
 	"log"
@@ -26,7 +25,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/client"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/go-connections/nat"
 )
@@ -40,7 +38,12 @@ func SetupLocal(
 	args *e2etesting.Args,
 	logger *log.Logger,
 ) (*testclient.Client, e2etesting.Cleanup, error) {
-	pubsubInfo, cleanupTf, err := setuptf.SetupTf(
+	// 1. Define basic cleanup that only does Terraform
+	cleanupTf := func() {
+		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, "tf/destroy", logger)
+	}
+
+	pubsubInfo, err := setuptf.SetupTf(
 		ctx,
 		args.ProjectID,
 		args.TestRunID,
@@ -49,6 +52,7 @@ func SetupLocal(
 		logger,
 	)
 	if err != nil {
+		// If SetupTf fails, we still want to try destroying workspace
 		return nil, cleanupTf, err
 	}
 
@@ -60,53 +64,45 @@ func SetupLocal(
 
 	createdRes, err := createContainer(ctx, cli, args, pubsubInfo, logger)
 	if err != nil {
-		if errdefs.IsNotFound(err) {
-			err = fmt.Errorf(
-				`docker image not found, try running "docker pull %v": %w`,
-				args.Local.Image,
-				err,
-			)
-		}
+		// Container creation failed, so no container to remove, but must cleanup TF
 		return nil, cleanupTf, err
 	}
 
-	if len(createdRes.Warnings) != 0 {
-		logger.Printf("Started with warnings: %v", createdRes.Warnings)
-	}
 	containerID := createdRes.ID
-	removeContainer := func() {
+
+	// 2. Now we have a container, update cleanup to do both!
+	cleanupAll := func() {
+		logger.Printf("Stopping and removing container ID %v\n", containerID)
+		timeout := 15
+		err := cli.ContainerStop(ctx, containerID, container.StopOptions{Timeout: &timeout})
+		if err != nil {
+			logger.Printf("Error stopping container: %v", err)
+		}
+
+		// Defer ensures they run even if something panics
 		defer cleanupTf()
+
 		err = cli.ContainerRemove(ctx, containerID, container.RemoveOptions{Force: true})
 		if err != nil {
-			logger.Panic(err)
+			logger.Printf("Error removing container: %v", err)
 		}
 	}
 
 	err = cli.ContainerStart(ctx, containerID, container.StartOptions{})
 	if err != nil {
-		return nil, removeContainer, err
-	}
-
-	cleanup := func() {
-		logger.Printf("Stopping and removing container ID %v\n", containerID)
-		timeout := 15
-		err = cli.ContainerStop(ctx, containerID, container.StopOptions{Timeout: &timeout})
-		defer removeContainer()
-		if err != nil {
-			logger.Panic(err)
-		}
+		return nil, cleanupAll, err
 	}
 
 	err = startForwardingContainerLogs(ctx, cli, containerID, logger)
 	if err != nil {
-		return nil, cleanup, err
+		return nil, cleanupAll, err
 	}
 
 	client, err := testclient.New(ctx, args.ProjectID, pubsubInfo)
 	if err != nil {
-		return nil, cleanup, err
+		return nil, cleanupAll, err
 	}
-	return client, cleanup, err
+	return client, cleanupAll, nil
 }
 
 func createContainer(

--- a/e2etestrunner/setuplocal.go
+++ b/e2etestrunner/setuplocal.go
@@ -16,6 +16,7 @@ package e2etestrunner
 
 import (
 	"context"
+	"fmt"
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-e2e-testing/e2etesting"
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-e2e-testing/e2etesting/setuptf"
 	"log"
@@ -25,6 +26,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/go-connections/nat"
 )
@@ -64,11 +66,21 @@ func SetupLocal(
 
 	createdRes, err := createContainer(ctx, cli, args, pubsubInfo, logger)
 	if err != nil {
+		if errdefs.IsNotFound(err) {
+			err = fmt.Errorf(
+				`docker image not found, try running "docker pull %v": %w`,
+				args.Local.Image,
+				err,
+			)
+		}
 		// Container creation failed, so no container to remove, but must cleanup TF
 		return nil, cleanupTf, err
 	}
 
 	containerID := createdRes.ID
+	if len(createdRes.Warnings) != 0 {
+		logger.Printf("Started with warnings: %v", createdRes.Warnings)
+	}
 
 	// 2. Now we have a container, update cleanup to do both!
 	cleanupAll := func() {

--- a/e2etestrunner/setuplocal.go
+++ b/e2etestrunner/setuplocal.go
@@ -40,7 +40,7 @@ func SetupLocal(
 ) (*testclient.Client, e2etesting.Cleanup, error) {
 	// 1. Define basic cleanup that only does Terraform
 	cleanupTf := func() {
-		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, "tf/destroy", logger)
+		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, logger)
 	}
 
 	pubsubInfo, err := setuptf.SetupTf(

--- a/e2etestrunner_collector/main_test.go
+++ b/e2etestrunner_collector/main_test.go
@@ -45,7 +45,11 @@ func TestMain(m *testing.M) {
 	}
 	cleanup, err := setupFunc(ctx, &args, logger)
 
-	defer cleanup()
+	if !args.SkipCleanup {
+		defer cleanup()
+	} else {
+		logger.Println("Skipping auto-cleanup (explicitly requested)")
+	}
 	if err != nil {
 		logger.Panic(err)
 	}

--- a/e2etestrunner_collector/setupgcecollector.go
+++ b/e2etestrunner_collector/setupgcecollector.go
@@ -32,7 +32,10 @@ func SetupGceCollector(
 	args *e2etesting.Args,
 	logger *log.Logger,
 ) (e2etesting.Cleanup, error) {
-	_, cleanupTf, err := setuptf.SetupTf(
+	cleanup := func() {
+		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, "tf/destroy", logger)
+	}
+	_, err := setuptf.SetupTf(
 		ctx,
 		args.ProjectID,
 		args.TestRunID,
@@ -42,6 +45,5 @@ func SetupGceCollector(
 		},
 		logger,
 	)
-
-	return cleanupTf, err
+	return cleanup, err
 }

--- a/e2etestrunner_collector/setupgcecollector.go
+++ b/e2etestrunner_collector/setupgcecollector.go
@@ -33,7 +33,7 @@ func SetupGceCollector(
 	logger *log.Logger,
 ) (e2etesting.Cleanup, error) {
 	cleanup := func() {
-		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, "tf/destroy", logger)
+		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, logger)
 	}
 	_, err := setuptf.SetupTf(
 		ctx,

--- a/e2etestrunner_collector/setupgcecollectorarm.go
+++ b/e2etestrunner_collector/setupgcecollectorarm.go
@@ -33,7 +33,7 @@ func SetupGceCollectorArm(
 	logger *log.Logger,
 ) (e2etesting.Cleanup, error) {
 	cleanup := func() {
-		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, "tf/destroy", logger)
+		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, logger)
 	}
 	_, err := setuptf.SetupTf(
 		ctx,

--- a/e2etestrunner_collector/setupgcecollectorarm.go
+++ b/e2etestrunner_collector/setupgcecollectorarm.go
@@ -32,7 +32,10 @@ func SetupGceCollectorArm(
 	args *e2etesting.Args,
 	logger *log.Logger,
 ) (e2etesting.Cleanup, error) {
-	_, cleanupTf, err := setuptf.SetupTf(
+	cleanup := func() {
+		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, "tf/destroy", logger)
+	}
+	_, err := setuptf.SetupTf(
 		ctx,
 		args.ProjectID,
 		args.TestRunID,
@@ -42,6 +45,5 @@ func SetupGceCollectorArm(
 		},
 		logger,
 	)
-
-	return cleanupTf, err
+	return cleanup, err
 }

--- a/e2etestrunner_collector/setupgcloudruncollector.go
+++ b/e2etestrunner_collector/setupgcloudruncollector.go
@@ -32,7 +32,10 @@ func SetupCloudRunCollector(
 	args *e2etesting.Args,
 	logger *log.Logger,
 ) (e2etesting.Cleanup, error) {
-	_, cleanupTf, err := setuptf.SetupTf(
+	cleanup := func() {
+		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, "tf/destroy", logger)
+	}
+	_, err := setuptf.SetupTf(
 		ctx,
 		args.ProjectID,
 		args.TestRunID,
@@ -42,6 +45,5 @@ func SetupCloudRunCollector(
 		},
 		logger,
 	)
-
-	return cleanupTf, err
+	return cleanup, err
 }

--- a/e2etestrunner_collector/setupgcloudruncollector.go
+++ b/e2etestrunner_collector/setupgcloudruncollector.go
@@ -33,7 +33,7 @@ func SetupCloudRunCollector(
 	logger *log.Logger,
 ) (e2etesting.Cleanup, error) {
 	cleanup := func() {
-		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, "tf/destroy", logger)
+		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, logger)
 	}
 	_, err := setuptf.SetupTf(
 		ctx,

--- a/e2etestrunner_collector/setupgkecollector.go
+++ b/e2etestrunner_collector/setupgkecollector.go
@@ -18,7 +18,10 @@ func SetupGkeCollector(
 	args *e2etesting.Args,
 	logger *log.Logger,
 ) (e2etesting.Cleanup, error) {
-	_, cleanupTf, err := setuptf.SetupTf(
+	cleanup := func() {
+		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, "tf/destroy", logger)
+	}
+	_, err := setuptf.SetupTf(
 		ctx,
 		args.ProjectID,
 		args.TestRunID,
@@ -28,6 +31,5 @@ func SetupGkeCollector(
 		},
 		logger,
 	)
-
-	return cleanupTf, err
+	return cleanup, err
 }

--- a/e2etestrunner_collector/setupgkecollector.go
+++ b/e2etestrunner_collector/setupgkecollector.go
@@ -19,7 +19,7 @@ func SetupGkeCollector(
 	logger *log.Logger,
 ) (e2etesting.Cleanup, error) {
 	cleanup := func() {
-		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, "tf/destroy", logger)
+		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, logger)
 	}
 	_, err := setuptf.SetupTf(
 		ctx,

--- a/e2etestrunner_collector/setupgkeoperatorcollector.go
+++ b/e2etestrunner_collector/setupgkeoperatorcollector.go
@@ -19,7 +19,7 @@ func SetupGkeOperatorCollector(
 	logger *log.Logger,
 ) (e2etesting.Cleanup, error) {
 	cleanup := func() {
-		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, "tf/destroy", logger)
+		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, logger)
 	}
 	_, err := setuptf.SetupTf(
 		ctx,

--- a/e2etestrunner_collector/setupgkeoperatorcollector.go
+++ b/e2etestrunner_collector/setupgkeoperatorcollector.go
@@ -18,7 +18,10 @@ func SetupGkeOperatorCollector(
 	args *e2etesting.Args,
 	logger *log.Logger,
 ) (e2etesting.Cleanup, error) {
-	_, cleanupTf, err := setuptf.SetupTf(
+	cleanup := func() {
+		setuptf.CleanupTf(ctx, args.ProjectID, args.TestRunID, "tf/destroy", logger)
+	}
+	_, err := setuptf.SetupTf(
 		ctx,
 		args.ProjectID,
 		args.TestRunID,
@@ -28,6 +31,5 @@ func SetupGkeOperatorCollector(
 		},
 		logger,
 	)
-
-	return cleanupTf, err
+	return cleanup, err
 }

--- a/tf/common/kubernetes-provider.tf
+++ b/tf/common/kubernetes-provider.tf
@@ -1,0 +1,26 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "google_container_cluster" "default" {
+  name     = local.gke_cluster_name
+  location = local.gke_cluster_location
+}
+
+data "google_client_config" "default" {}
+
+provider "kubernetes" {
+  host                   = "https://${data.google_container_cluster.default.endpoint}"
+  cluster_ca_certificate = base64decode(data.google_container_cluster.default.master_auth.0.cluster_ca_certificate)
+  token                  = data.google_client_config.default.access_token
+}

--- a/tf/destroy/kubernetes-provider.tf
+++ b/tf/destroy/kubernetes-provider.tf
@@ -1,0 +1,1 @@
+../common/kubernetes-provider.tf

--- a/tf/destroy/main-common.tf
+++ b/tf/destroy/main-common.tf
@@ -1,0 +1,1 @@
+../common/main-common.tf

--- a/tf/gae-standard/gae-standard.tf
+++ b/tf/gae-standard/gae-standard.tf
@@ -21,7 +21,7 @@ resource "google_app_engine_standard_app_version" "test_service" {
 
   version_id = "v1"
   project    = var.project_id
-  service    = "standard-${var.runtime}-${terraform.workspace}"
+  service    = "standard-${var.runtime}-${substr(replace(terraform.workspace, "-", ""), 0, 12)}"
   runtime    = var.runtime
 
   deployment {

--- a/tf/gae/gae.tf
+++ b/tf/gae/gae.tf
@@ -20,7 +20,7 @@
 resource "google_app_engine_flexible_app_version" "test_service" {
   version_id = "v1"
   project    = var.project_id
-  service    = "flex-${var.runtime}-${terraform.workspace}"
+  service    = "flex-${var.runtime}-${substr(replace(terraform.workspace, "-", ""), 0, 12)}"
   runtime    = "custom"
 
   deployment {

--- a/tf/gke-collector/gke-collector.tf
+++ b/tf/gke-collector/gke-collector.tf
@@ -12,18 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "google_container_cluster" "default" {
-  name     = local.gke_cluster_name
-  location = local.gke_cluster_location
-}
-
-data "google_client_config" "default" {}
-
-provider "kubernetes" {
-  host  = "https://${data.google_container_cluster.default.endpoint}"
-  cluster_ca_certificate = base64decode(data.google_container_cluster.default.master_auth.0.cluster_ca_certificate)
-  token = data.google_client_config.default.access_token
-}
 
 resource "kubernetes_pod" "collector" {
   metadata {

--- a/tf/gke-collector/kubernetes-provider.tf
+++ b/tf/gke-collector/kubernetes-provider.tf
@@ -1,0 +1,1 @@
+../common/kubernetes-provider.tf

--- a/tf/gke-operator-collector/gke-operator-collector.tf
+++ b/tf/gke-operator-collector/gke-operator-collector.tf
@@ -12,18 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "google_container_cluster" "default" {
-  name     = local.gke_cluster_name
-  location = local.gke_cluster_location
-}
-
-data "google_client_config" "default" {}
-
-provider "kubernetes" {
-  host  = "https://${data.google_container_cluster.default.endpoint}"
-  cluster_ca_certificate = base64decode(data.google_container_cluster.default.master_auth.0.cluster_ca_certificate)
-  token = data.google_client_config.default.access_token
-}
 
 resource "kubernetes_namespace_v1" "namespace" {
   metadata {

--- a/tf/gke-operator-collector/kubernetes-provider.tf
+++ b/tf/gke-operator-collector/kubernetes-provider.tf
@@ -1,0 +1,1 @@
+../common/kubernetes-provider.tf

--- a/tf/gke/gke.tf
+++ b/tf/gke/gke.tf
@@ -12,19 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "google_container_cluster" "default" {
-  name     = local.gke_cluster_name
-  location = local.gke_cluster_location
-}
-
-data "google_client_config" "default" {}
-
-provider "kubernetes" {
-  host                   = "https://${data.google_container_cluster.default.endpoint}"
-  cluster_ca_certificate = base64decode(data.google_container_cluster.default.master_auth.0.cluster_ca_certificate)
-  token                  = data.google_client_config.default.access_token
-}
-
 resource "kubernetes_pod" "testserver" {
   metadata {
     name = "testserver-${terraform.workspace}"

--- a/tf/gke/kubernetes-provider.tf
+++ b/tf/gke/kubernetes-provider.tf
@@ -1,0 +1,1 @@
+../common/kubernetes-provider.tf

--- a/tf/modules/repo-ci-triggers/main.tf
+++ b/tf/modules/repo-ci-triggers/main.tf
@@ -55,8 +55,6 @@ resource "google_cloudbuild_trigger" "ci" {
   ]
   include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
   service_account    = var.service_account
-
-
 }
 
 variable "service_account" {

--- a/tf/modules/repo-ci-triggers/main.tf
+++ b/tf/modules/repo-ci-triggers/main.tf
@@ -51,9 +51,22 @@ resource "google_cloudbuild_trigger" "ci" {
   name = "${local.repo_short_name}-e2e-${each.key}"
   tags = [
     local.repo_short_name,
-    each.key,
+    each.key
   ]
   include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
+  service_account    = var.service_account
+
+
+}
+
+variable "service_account" {
+  type        = string
+  description = "The service account to use for the triggers"
+  default     = null
+}
+variable "project_id" {
+  type        = string
+  description = "The GCP project ID"
 }
 
 variable "repository" {

--- a/tf/persistent/repo-ci-triggers.tf
+++ b/tf/persistent/repo-ci-triggers.tf
@@ -12,32 +12,83 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+locals {
+  service_account_email = "projects/${var.project_id}/serviceAccounts/e2e-cloudbuild-runner@${var.project_id}.iam.gserviceaccount.com"
+}
+
 module "python" {
-  source     = "../modules/repo-ci-triggers"
-  repository = "opentelemetry-operations-python"
-  run_on     = ["local", "gce", "gke", "gae", "gae-standard", "cloud-run", "cloud-functions-gen2"]
+  source          = "../modules/repo-ci-triggers"
+  project_id      = var.project_id
+  repository      = "opentelemetry-operations-python"
+  run_on          = ["local", "gce", "gke", "gae", "gae-standard", "cloud-run", "cloud-functions-gen2"]
+  service_account = local.service_account_email
 }
 
 module "java" {
-  source     = "../modules/repo-ci-triggers"
-  repository = "opentelemetry-operations-java"
-  run_on     = ["local", "gce", "gke", "gae", "cloud-run", "cloud-functions-gen2"]
+  source          = "../modules/repo-ci-triggers"
+  project_id      = var.project_id
+  repository      = "opentelemetry-operations-java"
+  run_on          = ["local", "gce", "gke", "gae", "cloud-run", "cloud-functions-gen2"]
+  service_account = local.service_account_email
 }
 
 module "js" {
-  source     = "../modules/repo-ci-triggers"
-  repository = "opentelemetry-operations-js"
-  run_on     = ["local", "gce", "gke", "gae", "gae-standard", "cloud-run", "cloud-functions-gen2"]
+  source          = "../modules/repo-ci-triggers"
+  project_id      = var.project_id
+  repository      = "opentelemetry-operations-js"
+  run_on          = ["local", "gce", "gke", "gae", "gae-standard", "cloud-run", "cloud-functions-gen2"]
+  service_account = local.service_account_email
 }
 
 module "go" {
-  source     = "../modules/repo-ci-triggers"
-  repository = "opentelemetry-operations-go"
-  run_on     = ["local", "gce", "gke", "gae", "gae-standard", "cloud-run", "cloud-functions-gen2"]
+  source          = "../modules/repo-ci-triggers"
+  project_id      = var.project_id
+  repository      = "opentelemetry-operations-go"
+  run_on          = ["local", "gce", "gke", "gae", "gae-standard", "cloud-run", "cloud-functions-gen2"]
+  service_account = local.service_account_email
+}
+module "e2e_testing" {
+  source          = "../modules/repo-ci-triggers"
+  project_id      = var.project_id
+  repository      = "opentelemetry-operations-e2e-testing"
+  run_on          = ["gke", "gce", "gae", "gae-standard", "cloud-run", "cloud-functions-gen2"]
+  service_account = local.service_account_email
 }
 
-module "e2e_testing" {
-  source     = "../modules/repo-ci-triggers"
-  repository = "opentelemetry-operations-e2e-testing"
-  run_on     = ["gke", "gce", "gae", "gae-standard", "cloud-run", "cloud-functions-gen2"]
+resource "google_pubsub_topic" "e2e_cleanup" {
+  name    = "e2e-cleanup"
+  project = var.project_id
+}
+
+resource "google_cloudbuild_trigger" "global_cleanup" {
+  name            = "global-e2e-cleanup"
+  description     = "Global cleanup for E2E tests triggered by Pub/Sub"
+  service_account = local.service_account_email
+
+  pubsub_config {
+    topic = google_pubsub_topic.e2e_cleanup.id
+  }
+
+  filter = "_BUILD_STATUS == 'SUCCESS' || _BUILD_STATUS == 'FAILURE'"
+
+  build {
+    step {
+      name = "$_TEST_RUNNER_IMAGE"
+      args = [
+        "cleanup",
+        "--project-id=${var.project_id}",
+        "--test-run-id=$_TEST_RUN_ID"
+      ]
+      dir = "/"
+    }
+    options {
+      logging = "CLOUD_LOGGING_ONLY"
+    }
+  }
+
+  substitutions = {
+    _TEST_RUN_ID       = "$(body.message.data.id)"
+    _TEST_RUNNER_IMAGE = "$(body.message.data.substitutions._TEST_RUNNER_IMAGE)"
+    _BUILD_STATUS      = "$(body.message.data.status)"
+  }
 }


### PR DESCRIPTION
This optionally moves the slow `terraform destroy` test teardown into a separate asynchronous Cloud Build trigger which is kicked off by a pub/sub notification from the actual test builds. The actual tests pass `--skip-cleanup` and can exit immediately once the assertions are over. [Example clean up run](https://pantheon.corp.google.com/cloud-build/builds;region=global/59eda775-f791-4f2e-bb21-95319c9946bc?e=TraceGenAiLaunch::TraceGenAiEnabled&mods=logs_tg_test&project=opentelemetry-ops-e2e).

- Speeds up GAE tests by 3-4 minutes and other environments by ~30-60 seconds
- Teardown always runs even if the test runner panics. Cloud Build handles sending pub/sub notifications for the build
- You can retry teardown steps if needed or use `gcloud builds submit` to clean up old jobs.

If everyone likes this change, we would update the other repo cloud build YAMLs [with this change](https://github.com/GoogleCloudPlatform/opentelemetry-operations-e2e-testing/pull/109/changes#diff-fa4cdc53d1ed47b786c68829a8e481e7ae7a1117b8aaa29d5a6b12971362d249). Note this change is "backward compatible" since you have to add the new `--skip-cleanup` flag to make the test return without cleanup.

---
**Before**

```mermaid
graph LR
    subgraph PR Status Check
        Test[Run Tests] --> Cleanup[Inline Cleanup]
        Cleanup --> Status[Report Status to PR]
    end
```

**After**
```mermaid
graph LR
    subgraph PR Status Check
        Test[Run Tests] --> Status[Report Status to PR]
    end
    Test --> Notify[Notify Pub/Sub]
    Notify --> Async[Async Cleanup]
```
